### PR TITLE
handle register files containing double quotes

### DIFF
--- a/csv.go
+++ b/csv.go
@@ -1,0 +1,84 @@
+package main
+
+import "io"
+
+type state int
+
+const (
+	// most common state. Outside of quoted field.
+	start state = iota
+	// in quoted field
+	quoted
+	// in quoted field and that previous character was a backslash
+	escape
+)
+
+type converter struct {
+	delegate  io.Reader
+	buf       []byte // place we read into
+	remaining []byte // what is still left to be read from
+	escaped   []byte // if non-empty, contains raw bytes ready to be copied to output, before remaining
+	s         state
+}
+
+func newConverter(r io.Reader) *converter {
+	return &converter{
+		delegate: r,
+		buf:      make([]byte, 4092),
+	}
+}
+
+func (c *converter) Read(p []byte) (n int, err error) {
+	if len(c.escaped) != 0 {
+		n = copy(p, c.escaped)
+		c.escaped = c.escaped[n:]
+		return n, nil
+	}
+
+	if len(c.remaining) == 0 {
+		n, err = c.delegate.Read(c.buf)
+		if n == 0 {
+			return n, err
+		}
+		c.remaining = c.buf[:n]
+	}
+
+	i := 0 // cursor to p
+	for i < len(p) && len(c.remaining) != 0 {
+		next := c.remaining[0]
+		c.remaining = c.remaining[1:]
+		switch c.s {
+		case start:
+			p[i] = next
+			i++
+			if next == '"' {
+				c.s = quoted
+			}
+		case quoted:
+			switch next {
+			case '"':
+				p[i] = next
+				i++
+				c.s = start
+			case '\\':
+				c.s = escape
+			default:
+				p[i] = next
+				i++
+			}
+		case escape:
+			switch next {
+			case '"':
+				c.escaped = []byte{'"', '"'}
+			case 'n':
+				c.escaped = []byte{'\n'}
+			default:
+				c.escaped = []byte{next}
+			}
+			c.s = quoted
+			return i, err
+		}
+	}
+
+	return i, err
+}

--- a/main.go
+++ b/main.go
@@ -127,7 +127,7 @@ type parser struct {
 func (p *parser) parseTransactions() {
 	out, err := exec.Command("ledger", "-f", *journal, "csv").Output()
 	checkf(err, "Unable to convert journal to csv. Possibly an issue with your ledger installation.")
-	r := csv.NewReader(bytes.NewReader(out))
+	r := csv.NewReader(newConverter(bytes.NewReader(out)))
 	var t txn
 	for {
 		cols, err := r.Read()


### PR DESCRIPTION
I've taken the csv conversion code I wrote for another project and
dropped it in here.  It takes the non-standard csv stream that ledger
produces and makes it rfc-4180-compliant.  A bit more about this here:
https://groups.google.com/forum/#!searchin/ledger-cli/gina$20csv%7Csort:relevance/ledger-cli/ibnbZzfT0BA/64vQ7yLYBAAJ

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/manishrjain/into-ledger/10)
<!-- Reviewable:end -->
