### PR TITLE
New -inverse flag, fixed crash-recovery and various fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /into-ledger
+/into-ledger.exe


### PR DESCRIPTION
New feature:
* -inverse flag changes the sign of amount found in .csv to the opposite.
  This is to support some Credit Cards (e.g. Discover) that report spending as positive values.

Crash-recovery fixed:
Completely reworked interaction with Bolt DB. Now it actually helps to recover previously
reconciled transactions after a crash by recovering assigned account and marking them "Done".

Other Fixes:
* Single-key keyboard entry support for Windows (was completely broken)
* Stable-sort of imported transaction to avoid reordering of same-day transactions.
  Also fixed byTime.Less to accommodate Stable-sort
* Remove account we are importing from, from classes during tf-idf model training
* Fixed topHits for cases when there are less than 5 accounts
* Start transaction indices from 1 (not 0) when displaying them
* Skipping transaction unmarks it as cleared