### PR TITLE
Pull in keyboard shortcuts file

### DIFF
--- a/main.go
+++ b/main.go
@@ -572,7 +572,7 @@ LOOP:
 	return 0
 }
 
-func (p *parser) categorizeTxn(t *Txn, idx, total int) float64 {
+func (p *parser) categorizeTxn(t *Txn, idx, total int, ks keys.Shortcuts) float64 {
 	clear()
 	printSummary(*t, idx, total)
 	fmt.Println()
@@ -590,8 +590,8 @@ func (p *parser) categorizeTxn(t *Txn, idx, total int) float64 {
 	fmt.Println()
 
 	hits := p.topHits(t.Desc)
-	var ks keys.Shortcuts
-	setDefaultMappings(&ks)
+	// var ks keys.Shortcuts
+	// setDefaultMappings(&ks)
 	for _, hit := range hits {
 		ks.AutoAssign(string(hit), "default")
 	}
@@ -618,7 +618,7 @@ func (p *parser) classifyTxn(t *Txn) {
 
 var lettersOnly = regexp.MustCompile("[^a-zA-Z]+")
 
-func (p *parser) showAndCategorizeTxns(rtxns []Txn) {
+func (p *parser) showAndCategorizeTxns(rtxns []Txn, short keys.Shortcuts) {
 	txns := rtxns
 	for {
 		for i := 0; i < len(txns); i++ {
@@ -659,7 +659,7 @@ func (p *parser) showAndCategorizeTxns(rtxns []Txn) {
 
 		for i := 0; i < len(txns) && i >= 0; {
 			t := &txns[i]
-			res := p.categorizeTxn(t, i, len(txns))
+			res := p.categorizeTxn(t, i, len(txns), short)
 			if res == 1.0 {
 				upto := applyToSimilarTxns(i)
 				if upto == i+1 {
@@ -975,7 +975,7 @@ func main() {
 	})
 	txns = p.categorizeByRules(txns)
 	txns = p.categorizeBelow(txns)
-	p.showAndCategorizeTxns(txns)
+	p.showAndCategorizeTxns(txns, *short)
 
 	final := p.iterateDB()
 	sort.Sort(byTime(final))


### PR DESCRIPTION
I don't expect I have this right, and my golang experience is minimal, but opening it to kick off a conversation on how to get the keyboard shortcuts in the shortcuts.yaml file pulled in.

I'm just getting started with ledger and using this on the sample drewr3.dat file (on Mac, you can see it at `/usr/local/Cellar/ledger/3.1.2/share/ledger/examples/`). After getting a basic bank transactions csv that I pulled using https://github.com/ebridges/plaid2qif, I saw something like this:
![image](https://user-images.githubusercontent.com/5614134/52932761-b8cff400-3305-11e9-9364-bae4afa6d9fe.png)

I wanted to have all the predefined shortcuts from the `~/.into-ledger/shortcuts.yaml` filed pulled in, but I couldn't figure out how.

After patching the code, I see more options, for example:
![image](https://user-images.githubusercontent.com/5614134/52933111-06009580-3307-11e9-832e-fd18b115700f.png)


Incidentally, it seems like the auto-population from the ledger should be after the shortcuts.yaml in precedence.
